### PR TITLE
Fix broken EDM window det_bunches for PLL

### DIFF
--- a/epics/opi/mbf/det_bunches.edl
+++ b/epics/opi/mbf/det_bunches.edl
@@ -41,7 +41,7 @@ fontAlign "center"
 fgColor index 14
 bgColor index 73
 value {
-  "$(device):$(axis):DET:$(det) Bunch Enables"
+  "$(device):$(axis):$(det) Bunch Enables"
 }
 endObjectProperties
 
@@ -125,7 +125,7 @@ y2Max 1
 # Trace Properties
 numTraces 1
 yPv {
-  0 "$(device):$(axis):DET:$(det):BUNCHES_S"
+  0 "$(device):$(axis):$(det):BUNCHES_S"
 }
 plotUpdateMode {
   0 "y"
@@ -163,7 +163,7 @@ x 16
 y 232
 w 184
 h 20
-controlPv "$(device):$(axis):DET:$(det):BUNCH_SELECT_S"
+controlPv "$(device):$(axis):$(det):BUNCH_SELECT_S"
 font "helvetica-medium-r-14.0"
 fontAlign "right"
 fgColor index 14
@@ -229,7 +229,7 @@ onColor index 4
 offColor index 3
 topShadowColor index 1
 botShadowColor index 14
-controlPv "$(device):$(axis):DET:$(det):SET_SELECT_S.PROC"
+controlPv "$(device):$(axis):$(det):SET_SELECT_S.PROC"
 pressValue "0"
 onLabel "Enable"
 offLabel "Enable"
@@ -247,7 +247,7 @@ x 64
 y 264
 w 240
 h 16
-controlPv "$(device):$(axis):DET:$(det):SELECT_STATUS"
+controlPv "$(device):$(axis):$(det):SELECT_STATUS"
 font "helvetica-medium-r-14.0"
 fgColor index 14
 bgColor index 0
@@ -276,7 +276,7 @@ fgColor index 14
 fgAlarm
 bgColor index 0
 useDisplayBg
-alarmPv "$(device):$(axis):DET:$(det):SELECT_STATUS"
+alarmPv "$(device):$(axis):$(det):SELECT_STATUS"
 value {
   "Status:"
 }
@@ -298,7 +298,7 @@ onColor index 4
 offColor index 3
 topShadowColor index 1
 botShadowColor index 14
-controlPv "$(device):$(axis):DET:$(det):RESET_SELECT_S.PROC"
+controlPv "$(device):$(axis):$(det):RESET_SELECT_S.PROC"
 pressValue "0"
 onLabel "Disable"
 offLabel "Disable"

--- a/epics/opi/mbf/det_detail.edl
+++ b/epics/opi/mbf/det_detail.edl
@@ -19,7 +19,7 @@ ctlBgColor1 index 0
 ctlBgColor2 index 14
 topShadowColor index 0
 botShadowColor index 14
-title "$(device):$(axis):DET:$(det) IQ"
+title "$(device):$(axis):$(det) IQ"
 showGrid
 snapToGrid
 gridSize 8
@@ -41,7 +41,7 @@ fontAlign "center"
 fgColor index 14
 bgColor index 73
 value {
-  "$(device):$(axis):DET:$(det) IQ"
+  "$(device):$(axis):$(det) IQ"
 }
 endObjectProperties
 
@@ -121,10 +121,10 @@ y2Max 1
 # Trace Properties
 numTraces 1
 xPv {
-  0 "$(device):$(axis):DET:$(det):I"
+  0 "$(device):$(axis):$(det):I"
 }
 yPv {
-  0 "$(device):$(axis):DET:$(det):Q"
+  0 "$(device):$(axis):$(det):Q"
 }
 plotStyle {
   0 "point"
@@ -154,7 +154,7 @@ lineColor index 14
 fill
 fillColor index 16
 fillAlarm
-alarmPv "$(device):$(axis):DET:$(det):OUT_OVF"
+alarmPv "$(device):$(axis):$(det):OUT_OVF"
 endObjectProperties
 
 # (Text Monitor)
@@ -167,7 +167,7 @@ x 136
 y 496
 w 48
 h 16
-controlPv "$(device):$(axis):DET:$(det):OUT_OVF"
+controlPv "$(device):$(axis):$(det):OUT_OVF"
 font "helvetica-medium-r-12.0"
 fgColor index 14
 bgColor index 0
@@ -191,7 +191,7 @@ x 56
 y 496
 w 56
 h 16
-controlPv "$(device):$(axis):DET:$(det):MAX_POWER"
+controlPv "$(device):$(axis):$(det):MAX_POWER"
 font "helvetica-medium-r-14.0"
 fgColor index 14
 fgAlarm
@@ -243,7 +243,7 @@ bgColor index 3
 inconsistentColor index 0
 topShadowColor index 1
 botShadowColor index 11
-controlPv "$(device):$(axis):DET:$(det):SCALING_S"
+controlPv "$(device):$(axis):$(det):SCALING_S"
 font "helvetica-medium-r-12.0"
 endObjectProperties
 
@@ -277,7 +277,7 @@ x 392
 y 496
 w 32
 h 16
-controlPv "$(device):$(axis):DET:$(det):COUNT"
+controlPv "$(device):$(axis):$(det):COUNT"
 font "helvetica-medium-r-14.0"
 fgColor index 14
 fgAlarm

--- a/epics/opi/mbf/det_state.edl
+++ b/epics/opi/mbf/det_state.edl
@@ -63,7 +63,7 @@ bgColor index 3
 inconsistentColor index 0
 topShadowColor index 1
 botShadowColor index 11
-controlPv "$(device):$(axis):DET:$(det):ENABLE_S"
+controlPv "$(device):$(axis):$(det):ENABLE_S"
 font "helvetica-medium-r-12.0"
 endObjectProperties
 
@@ -81,7 +81,7 @@ lineColor index 14
 fill
 fillColor index 16
 fillAlarm
-alarmPv "$(device):$(axis):DET:$(det):OUT_OVF"
+alarmPv "$(device):$(axis):$(det):OUT_OVF"
 endObjectProperties
 
 # (Text Monitor)
@@ -94,7 +94,7 @@ x 352
 y 8
 w 72
 h 16
-controlPv "$(device):$(axis):DET:$(det):OUT_OVF"
+controlPv "$(device):$(axis):$(det):OUT_OVF"
 font "helvetica-medium-r-12.0"
 fgColor index 14
 bgColor index 0
@@ -146,7 +146,7 @@ bgColor index 3
 inconsistentColor index 0
 topShadowColor index 1
 botShadowColor index 11
-controlPv "$(device):$(axis):DET:$(det):SCALING_S"
+controlPv "$(device):$(axis):$(det):SCALING_S"
 font "helvetica-medium-r-12.0"
 endObjectProperties
 
@@ -183,7 +183,7 @@ x 232
 y 28
 w 32
 h 16
-controlPv "$(device):$(axis):DET:$(det):COUNT"
+controlPv "$(device):$(axis):$(det):COUNT"
 font "helvetica-medium-r-14.0"
 fgColor index 14
 fgAlarm
@@ -208,7 +208,7 @@ x 272
 y 8
 w 56
 h 16
-controlPv "$(device):$(axis):DET:$(det):MAX_POWER"
+controlPv "$(device):$(axis):$(det):MAX_POWER"
 font "helvetica-medium-r-14.0"
 fgColor index 14
 fgAlarm
@@ -259,7 +259,7 @@ fgColor index 14
 bgColor index 0
 useDisplayBg
 value {
-  "DET $(det)"
+  "$(det)"
 }
 autoSize
 endObjectProperties

--- a/epics/opi/mbf/det_waveforms.edl
+++ b/epics/opi/mbf/det_waveforms.edl
@@ -19,7 +19,7 @@ ctlBgColor1 index 0
 ctlBgColor2 index 14
 topShadowColor index 0
 botShadowColor index 14
-title "$(device):$(axis):DET:$(det) Waveforms"
+title "$(device):$(axis):$(det) Waveforms"
 showGrid
 snapToGrid
 gridSize 8
@@ -65,8 +65,8 @@ xPv {
   1 "$(device):$(axis):DET:$(x_axis)"
 }
 yPv {
-  0 "$(device):$(axis):DET:$(det):I"
-  1 "$(device):$(axis):DET:$(det):Q"
+  0 "$(device):$(axis):$(det):I"
+  1 "$(device):$(axis):$(det):Q"
 }
 plotUpdateMode {
   0 "y"
@@ -97,7 +97,7 @@ fontAlign "center"
 fgColor index 14
 bgColor index 73
 value {
-  "$(device):$(axis):DET:$(det) Waveforms"
+  "$(device):$(axis):$(det) Waveforms"
 }
 endObjectProperties
 
@@ -182,7 +182,7 @@ xPv {
   0 "$(device):$(axis):DET:$(x_axis)"
 }
 yPv {
-  0 "$(device):$(axis):DET:$(det):POWER"
+  0 "$(device):$(axis):$(det):POWER"
 }
 plotUpdateMode {
   0 "y"
@@ -257,7 +257,7 @@ xPv {
   0 "$(device):$(axis):DET:$(x_axis)"
 }
 yPv {
-  0 "$(device):$(axis):DET:$(det):PHASE"
+  0 "$(device):$(axis):$(det):PHASE"
 }
 plotStyle {
   0 "point"
@@ -317,7 +317,7 @@ lineColor index 14
 fill
 fillColor index 16
 fillAlarm
-alarmPv "$(device):$(axis):DET:$(det):OUT_OVF"
+alarmPv "$(device):$(axis):$(det):OUT_OVF"
 endObjectProperties
 
 # (Text Monitor)
@@ -330,7 +330,7 @@ x 312
 y 600
 w 48
 h 16
-controlPv "$(device):$(axis):DET:$(det):OUT_OVF"
+controlPv "$(device):$(axis):$(det):OUT_OVF"
 font "helvetica-medium-r-12.0"
 fgColor index 14
 bgColor index 0
@@ -354,7 +354,7 @@ x 232
 y 600
 w 56
 h 16
-controlPv "$(device):$(axis):DET:$(det):MAX_POWER"
+controlPv "$(device):$(axis):$(det):MAX_POWER"
 font "helvetica-medium-r-14.0"
 fgColor index 14
 fgAlarm
@@ -406,7 +406,7 @@ bgColor index 3
 inconsistentColor index 0
 topShadowColor index 1
 botShadowColor index 11
-controlPv "$(device):$(axis):DET:$(det):SCALING_S"
+controlPv "$(device):$(axis):$(det):SCALING_S"
 font "helvetica-medium-r-12.0"
 endObjectProperties
 

--- a/epics/opi/mbf/detector.edl
+++ b/epics/opi/mbf/detector.edl
@@ -212,7 +212,7 @@ displayFileName {
   0 "mbf/det_state.edl"
 }
 symbols {
-  0 "det=0"
+  0 "det=DET:0"
 }
 noScroll
 endObjectProperties
@@ -240,7 +240,7 @@ displayFileName {
   0 "mbf/det_state.edl"
 }
 symbols {
-  0 "det=1"
+  0 "det=DET:1"
 }
 noScroll
 endObjectProperties
@@ -268,7 +268,7 @@ displayFileName {
   0 "mbf/det_state.edl"
 }
 symbols {
-  0 "det=2"
+  0 "det=DET:2"
 }
 noScroll
 endObjectProperties
@@ -296,7 +296,7 @@ displayFileName {
   0 "mbf/det_state.edl"
 }
 symbols {
-  0 "det=3"
+  0 "det=DET:3"
 }
 noScroll
 endObjectProperties


### PR DESCRIPTION
While I wanted to use the Tune PLL I saw that there is an issue with the associated EDM windows.

When we open the bunches selector (with the button "Bunches") the new windows is not working fine because the PV names are incorrect. This is a compatibility issue with the 4 other (regular) detectors.

![06-Mar-24-211754](https://github.com/DLS-Controls-Private-org/DLS-MBF/assets/37065385/df10b398-ba5d-490f-ba3e-213c330eefe4)

This can be fixed by changing how the detector name is passed to the "Bunches Selector" window, I have done the modification, available in this pull request, and tested it. For me it seems OK now, but only tested it for TMBF (we only have TMBF at ESRF). It could be useful if someone wants to test it for the LMBF (if applicable) before a possible merge in the master branch.