### PR TITLE
Improves DAC delay reset

### DIFF
--- a/epics/src/delay.c
+++ b/epics/src/delay.c
@@ -351,6 +351,13 @@ static void reset_coarse_delay(void)
     if (clock_passthrough)
         return;
 
+    /* Fine delay is set to zero before performing a reset on the coarse delay,
+     * its value is set back after.
+     * This procedure ensures a better reproducibility of the DAC FIFO
+     * alignment across all possible values for the fine delay. */
+    unsigned int dac_fine_delay_setpoint = dac_fine_delay;
+    slew_dac_fine_delay(0);
+
     pll_sync();
     reset_dac_pll();
     WRITE_OUT_RECORD(ulongout, coarse_delay_pv, 0, false);
@@ -359,6 +366,7 @@ static void reset_coarse_delay(void)
     /* After this reset trigger a turn resync.  Need to wait a little for the
      * dust to settle first! */
     usleep(50000);
+    slew_dac_fine_delay(dac_fine_delay_setpoint);
     hw_write_turn_clock_sync();
 }
 


### PR DESCRIPTION
This pull request improves the reproducibility of the DAC FIFO alignment. Without it, we experienced a change of bunch alignment after a restart of the MBF IOC, specially after the DAC delays (fine and coarse) were adjusted.

It was found that it is due to the fact that we have a DAC "fine delay" different than zero. When the MBF IOC is started the DAC coarse delay is reset with the fine delay at 0, but when this reset is performed by hand the fine delay it not necessarily at zero. The difference of fine delay value during the "coarse delay reset" affects the FIFO alignment procedure.

The proposed solution is to set the fine delay at zero before doing any DAC coarse delay reset, and set back the nominal value afterwards. It was tested in the lab and seems to work without side effects.